### PR TITLE
[ANALYZER-2443]  3 minor changes:

### DIFF
--- a/src/org/pentaho/mongo/MongoProperties.java
+++ b/src/org/pentaho/mongo/MongoProperties.java
@@ -7,6 +7,11 @@ public class MongoProperties {
 
   private final Map<MongoProp, String> props = new HashMap<MongoProp, String>();
 
+  public MongoProperties() {
+    // defaults
+    props.put( MongoProp.PASSWORD, "" );
+  }
+
   public MongoProperties set( MongoProp prop, String value ) {
     props.put( prop, value );
     return this;

--- a/src/org/pentaho/mongo/wrapper/MongoClientWrapperFactory.java
+++ b/src/org/pentaho/mongo/wrapper/MongoClientWrapperFactory.java
@@ -11,7 +11,7 @@ import org.pentaho.mongo.MongoProperties;
 public class MongoClientWrapperFactory {
   public static MongoClientWrapper createMongoClientWrapper( MongoProperties props, MongoUtilLogger log )
       throws MongoDbException {
-    if ( Boolean.getBoolean( props.get( MongoProp.USE_KERBEROS ) ) ) {
+    if ( Boolean.parseBoolean( props.get( MongoProp.USE_KERBEROS ) ) ) {
       KerberosMongoClientWrapper wrapper = new KerberosMongoClientWrapper( props, log );
       return (MongoClientWrapper) Proxy.newProxyInstance( wrapper.getClass().getClassLoader(),
         new Class<?>[] { MongoClientWrapper.class },


### PR DESCRIPTION
 1) added a test for cursor functionality,
 2) fixed an incorrect usage of getBoolean where parseBoolean was intended
 3) set a default value of empty string for PASSWORD to avoid NPEs in cases where password is not set and auth is used (as with Kerberos).
