### PR TITLE
[SP-2700] Backport of PDI-14736 - MongoDB Input/Output steps fail whe…

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -15,4 +15,4 @@ project.revision=6.1-SNAPSHOT
 #version.for.license.class=com/pentaho/analysis/mongo/Version.java
 #version.for.license=${project.revision}
 
-dependency.mongo-driver.revision=2.13.0
+dependency.mongo-driver.revision=2.13.3

--- a/test.properties
+++ b/test.properties
@@ -1,12 +1,34 @@
+#
+#  PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
+#
+#  Copyright 2002 - 2016 Pentaho Corporation (Pentaho). All rights reserved.
+#
+#  NOTICE: All information including source code contained herein is, and
+#  remains the sole property of Pentaho and its licensors. The intellectual
+#  and technical concepts contained herein are proprietary and confidential
+#  to, and are trade secrets of Pentaho and may be covered by U.S. and foreign
+#  patents, or patents in process, and are protected by trade secret and
+#  copyright laws. The receipt or possession of this source code and/or related
+#  information does not convey or imply any rights to reproduce, disclose or
+#  distribute its contents, or to manufacture, use, or sell anything that it
+#  may describe, in whole or in part. Any reproduction, modification, distribution,
+#  or public display of this information without the express written authorization
+#  from Pentaho is strictly prohibited and in violation of applicable laws and
+#  international treaties. Access to the source code contained herein is strictly
+#  prohibited to anyone except those individuals and entities who have executed
+#  confidentiality and non-disclosure agreements or other agreements with Pentaho,
+#  explicitly covering such access.
+#
+
 # properties for testing with CR credentials.
-single.server.host=bad-mongodb-260-kerb-n1
+single.server.host=bad-mongodb-301-kerb-n1.pentaho.dmz
 userpass.auth.port=27017
 userpass.auth.user=PentahoUser
 userpass.auth.password=password
 test.db=foodmart
 
-multiserver.host=bad-mongodb-260-kerb-n1:27017,bad-mongodb-260-kerb-n2:27017,bad-mongodb-260-kerb-n3:27017,bad-mongodb-260-kerb-n4:27017,bad-mongodb-260-kerb-n5:27017
-ssl.host=bad-mongodb-260-ssl-n1:27017,bad-mongodb-260-ssl-n2:27017,bad-mongodb-260-ssl-n3:27017,bad-mongodb-260-ssl-n4:27017,bad-mongodb-260-ssl-n5:27017
+multiserver.host=bad-mongodb-301-kerb-n1:27017,bad-mongodb-301-kerb-n2:27017,bad-mongodb-301-kerb-n3:27017,bad-mongodb-301-kerb-n4:27017,bad-mongodb-301-kerb-n5:27017
+ssl.host=bad-mongodb-301-ssl-n1.pentaho.dmz:27017,bad-mongodb-301-ssl-n2.pentaho.dmz:27017,bad-mongodb-301-ssl-n3.pentaho.dmz:27017,bad-mongodb-301-ssl-n4.pentaho.dmz:27017,bad-mongodb-301-ssl-n5.pentaho.dmz:27017
 
 ssl.user=admin
 ssl.password=admin


### PR DESCRIPTION
…n Authentication is used in MongoDB (6.1 Suite)

- updated mongo-java-driver version to 2.13.3