### PR TITLE
[BACKLOG-21568] Updates MongoDB driver from 3.2.2 to 3.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <url>scm:git:git@github.com:pentaho/${project.artifactId}.git</url>
   </scm>
   <properties>
-    <mongo-java-driver.version>3.2.2</mongo-java-driver.version>
+    <mongo-java-driver.version>3.6.3</mongo-java-driver.version>
     <mockito-all.version>1.9.5</mockito-all.version>
     <junit.version>4.4</junit.version>
   </properties>


### PR DESCRIPTION
Related PRs:
https://github.com/pentaho/pentaho-mongodb-plugin/pull/164
https://github.com/pentaho/pentaho-mongo-utils/pull/65
https://github.com/pentaho/pdi-dataservice-server-plugin/pull/282
https://github.com/pentaho/pentaho-karaf-assembly/pull/4214