### PR TITLE
[BACKLOG-22528] Changes aggregate function to use MongoDB cursors

### DIFF
--- a/src/main/java/org/pentaho/mongo/wrapper/collection/DefaultMongoCollectionWrapper.java
+++ b/src/main/java/org/pentaho/mongo/wrapper/collection/DefaultMongoCollectionWrapper.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+* Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,13 +18,16 @@
 package org.pentaho.mongo.wrapper.collection;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
 
 import org.pentaho.mongo.MongoDbException;
 import org.pentaho.mongo.wrapper.cursor.DefaultCursorWrapper;
 import org.pentaho.mongo.wrapper.cursor.MongoCursorWrapper;
 
-import com.mongodb.AggregationOutput;
+import com.mongodb.AggregationOptions;
 import com.mongodb.BasicDBObject;
+import com.mongodb.Cursor;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
@@ -43,8 +46,17 @@ public class DefaultMongoCollectionWrapper implements MongoCollectionWrapper {
   }
 
   @Override
-  public AggregationOutput aggregate( DBObject firstP, DBObject[] remainder ) throws MongoDbException {
-    return collection.aggregate( firstP, remainder );
+  public Cursor aggregate( List<? extends DBObject> pipeline, AggregationOptions options ) {
+    return collection.aggregate( pipeline, options );
+  }
+
+  @Override
+  public Cursor aggregate( DBObject firstP, DBObject[] remainder ) {
+    AggregationOptions options = AggregationOptions.builder().build();
+    List<DBObject> pipeline = new ArrayList<>();
+    pipeline.add( firstP );
+    Collections.addAll( pipeline, remainder );
+    return aggregate( pipeline, options );
   }
 
   @Override

--- a/src/main/java/org/pentaho/mongo/wrapper/collection/MongoCollectionWrapper.java
+++ b/src/main/java/org/pentaho/mongo/wrapper/collection/MongoCollectionWrapper.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+* Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@ package org.pentaho.mongo.wrapper.collection;
 
 import java.util.List;
 
-import org.pentaho.mongo.MongoDbException;
-import org.pentaho.mongo.wrapper.cursor.MongoCursorWrapper;
-
-import com.mongodb.AggregationOutput;
+import com.mongodb.AggregationOptions;
 import com.mongodb.BasicDBObject;
+import com.mongodb.Cursor;
 import com.mongodb.DBObject;
 import com.mongodb.WriteResult;
+import org.pentaho.mongo.MongoDbException;
+import org.pentaho.mongo.wrapper.cursor.MongoCursorWrapper;
 
 /**
  * Defines the wrapper interface for all interactions with a MongoCollection via
@@ -37,7 +37,9 @@ public interface MongoCollectionWrapper {
 
   MongoCursorWrapper find( DBObject dbObject, DBObject dbObject2 ) throws MongoDbException;
 
-  AggregationOutput aggregate( DBObject firstP, DBObject[] remainder ) throws MongoDbException;
+  Cursor aggregate( List<? extends DBObject> pipeline, AggregationOptions options );
+
+  Cursor aggregate( DBObject firstP, DBObject[] remainder ) throws MongoDbException;
 
   MongoCursorWrapper find() throws MongoDbException;
 


### PR DESCRIPTION
Fixed issue with pentaho-mongo-utils, this 'should' be good to go now.

Needs to be merged with https://github.com/pentaho/pentaho-mongodb-plugin/pull/167