### PR TITLE
PDI-17228 - Allow PLAIN auth mechanism to be used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target
 *.iml
 .idea
 pentaho-mongo-utils.iml
+.classpath
+.project
+.settings/

--- a/src/main/java/org/pentaho/mongo/wrapper/UsernamePasswordMongoClientWrapper.java
+++ b/src/main/java/org/pentaho/mongo/wrapper/UsernamePasswordMongoClientWrapper.java
@@ -1,5 +1,5 @@
 /*!
-  * Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+  * Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.
@@ -71,19 +71,24 @@ class UsernamePasswordMongoClientWrapper extends NoAuthMongoClientWrapper {
       authMecha = "";
     }
 
-    if ( authMecha.equals( "SCRAM-SHA-1" ) ) {
+    //Use the AuthDatabase if one was supplied, otherwise use the connecting database
+    authDatabase = ( authDatabase == null || authDatabase.trim().isEmpty() )
+                      ? props.get( MongoProp.DBNAME ) : authDatabase;
+
+    if ( authMecha.equalsIgnoreCase( "SCRAM-SHA-1" ) ) {
       credList.add( MongoCredential.createScramSha1Credential(
         props.get( MongoProp.USERNAME ),
-        authDatabase == null || authDatabase.equals( "" )
-          ?
-            props.get( MongoProp.DBNAME ) : authDatabase,
+        authDatabase,
         props.get( MongoProp.PASSWORD ).toCharArray() ) );
+    } else if ( authMecha.equalsIgnoreCase( "PLAIN" ) ) {
+      credList.add( MongoCredential.createPlainCredential(
+          props.get( MongoProp.USERNAME ),
+          authDatabase,
+          props.get( MongoProp.PASSWORD ).toCharArray() ) );
     } else {
       credList.add( MongoCredential.createCredential(
         props.get( MongoProp.USERNAME ),
-        authDatabase == null || authDatabase.equals( "" ) // Backward compatibility --Kaa
-          ?
-            props.get( MongoProp.DBNAME ) : authDatabase,
+        authDatabase,
         props.get( MongoProp.PASSWORD ).toCharArray() ) );
     }
     return credList;

--- a/src/test/java/org/pentaho/mongo/wrapper/UsernamePasswordMongoClientWrapperTest.java
+++ b/src/test/java/org/pentaho/mongo/wrapper/UsernamePasswordMongoClientWrapperTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,25 +139,30 @@ public class UsernamePasswordMongoClientWrapperTest {
     final String username = "testuser";
     final String password = "testpass";
     final String dbName = "database";
-    final String authMecha = "SCRAM-SHA-1";
 
-    // MongoProp.AUTH_DATABASE is null
-    mongoPropertiesBuilder = new MongoProperties.Builder()
-      .set( MongoProp.USERNAME, username )
-      .set( MongoProp.PASSWORD, password )
-      .set( MongoProp.AUTH_DATABASE, "" )
-      .set( MongoProp.DBNAME, dbName )
-      .set( MongoProp.AUTH_MECHA, authMecha );
+    final String[] authMechas = { "SCRAM-SHA-1", "PLAIN" };
 
-    UsernamePasswordMongoClientWrapper mongoClientWrapper =
-      new UsernamePasswordMongoClientWrapper( mongoPropertiesBuilder.build(), log );
-    List<MongoCredential> credentials = mongoClientWrapper.getCredentialList();
-    Assert.assertEquals( 1, credentials.size() );
-    Assert.assertEquals( authMecha, credentials.get( 0 ).getMechanism() );
-    Assert.assertEquals( username, credentials.get( 0 ).getUserName() );
-    Assert.assertEquals( dbName, credentials.get( 0 ).getSource() );
-    Assert.assertArrayEquals( password.toCharArray(), credentials.get( 0 ).getPassword() );
+    for ( String authMecha : authMechas ) {
+
+      // MongoProp.AUTH_DATABASE is null
+      mongoPropertiesBuilder =
+          new MongoProperties.Builder()
+                              .set( MongoProp.USERNAME, username )
+                              .set( MongoProp.PASSWORD, password )
+                              .set( MongoProp.AUTH_DATABASE, "" )
+                              .set( MongoProp.DBNAME, dbName )
+                              .set( MongoProp.AUTH_MECHA, authMecha );
+
+      UsernamePasswordMongoClientWrapper mongoClientWrapper =
+          new UsernamePasswordMongoClientWrapper( mongoPropertiesBuilder.build(), log );
+      List<MongoCredential> credentials = mongoClientWrapper.getCredentialList();
+      Assert.assertEquals( 1, credentials.size() );
+      Assert.assertEquals( authMecha, credentials.get( 0 ).getMechanism() );
+      Assert.assertEquals( username, credentials.get( 0 ).getUserName() );
+      Assert.assertEquals( dbName, credentials.get( 0 ).getSource() );
+      Assert.assertArrayEquals( password.toCharArray(), credentials.get( 0 ).getPassword() );
+
+    }
   }
-
 
 }


### PR DESCRIPTION
This is required if your mongo server is setup to do proxy LDAP authentication