### PR TITLE
[PDI-18180] Upgrade mongodb java driver for eventual support of Mongo…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <url>scm:git:git@github.com:pentaho/${project.artifactId}.git</url>
   </scm>
   <properties>
-    <mongo-java-driver.version>3.6.3</mongo-java-driver.version>
+    <mongo-java-driver.version>3.10.2</mongo-java-driver.version>
     <mockito-all.version>1.9.5</mockito-all.version>
     <junit.version>4.4</junit.version>
   </properties>


### PR DESCRIPTION
…DB4.x

- Update pom to use mongo-java-driver version 3.10.2