### PR TITLE
[PDI-19163] Upgraded mongo java driver version from 3.10.2 to 3.12.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <url>scm:git:git@github.com:pentaho/${project.artifactId}.git</url>
   </scm>
   <properties>
-    <mongo-java-driver.version>3.10.2</mongo-java-driver.version>
+    <mongo-java-driver.version>3.12.10</mongo-java-driver.version>
     <mockito-all.version>1.9.5</mockito-all.version>
     <junit.version>4.4</junit.version>
   </properties>


### PR DESCRIPTION
Upgrading java mongo driver to the latest possible version without many changes in the code.