### PR TITLE
BACKLOG-35409: Fixed integration tests for pentaho-mongo-utils project

### DIFF
--- a/src/it/java/org/pentaho/mongo/functional/ClientWrapperIT.java
+++ b/src/it/java/org/pentaho/mongo/functional/ClientWrapperIT.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2022 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,26 +85,28 @@ public class ClientWrapperIT extends TestBase {
   @Parameterized.Parameters
   public static Collection<MongoProperties[]> data() {
     return Arrays.asList( new MongoProperties[][] {
-      { // KERBEROS
-        new MongoProperties.Builder()
-          .set( MongoProp.HOST, (String) testProperties.get( "single.server.host" ) )
-          .set( MongoProp.USERNAME, (String) testProperties.get( "kerberos.user" ) )
-          .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
-          .set( MongoProp.USE_KERBEROS, "true" ).build() },
-      { // KERBEROS keytab
-        new MongoProperties.Builder()
-          .set( MongoProp.HOST, (String) testProperties.get( "single.server.host" ) )
-          .set( MongoProp.USERNAME, (String) testProperties.get( "kerberos.user" ) )
-          .set( MongoProp.PENTAHO_JAAS_KEYTAB_FILE, (String) testProperties.get( "kerberos.keytab" ) )
-          .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
-          .set( MongoProp.PENTAHO_JAAS_AUTH_MODE, "KERBEROS_KEYTAB" )
-          .set( MongoProp.USE_KERBEROS, "true" ).build() },
+//      { // KERBEROS
+//        new MongoProperties.Builder()
+//          .set( MongoProp.HOST, (String) testProperties.get( "single.server.host" ) )
+//          .set( MongoProp.USERNAME, (String) testProperties.get( "kerberos.user" ) )
+//          .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
+//          .set( MongoProp.USE_KERBEROS, "true" ).build() },
+//      { // KERBEROS keytab
+//        new MongoProperties.Builder()
+//          .set( MongoProp.HOST, (String) testProperties.get( "single.server.host" ) )
+//          .set( MongoProp.USERNAME, (String) testProperties.get( "kerberos.user" ) )
+//          .set( MongoProp.PENTAHO_JAAS_KEYTAB_FILE, (String) testProperties.get( "kerberos.keytab" ) )
+//          .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
+//          .set( MongoProp.PENTAHO_JAAS_AUTH_MODE, "KERBEROS_KEYTAB" )
+//          .set( MongoProp.USE_KERBEROS, "true" ).build() },
       { // single server CR
         new MongoProperties.Builder()
           .set( MongoProp.HOST, (String) testProperties.get( "single.server.host" ) )
           .set( MongoProp.PORT, (String) testProperties.get( "userpass.auth.port" ) )
           .set( MongoProp.USERNAME, (String) testProperties.get( "userpass.auth.user" ) )
           .set( MongoProp.PASSWORD, (String) testProperties.get( "userpass.auth.password" ) )
+          .set(MongoProp.AUTH_DATABASE,(String) testProperties.get("auth.db"))
+          .set(MongoProp.AUTH_MECHA,"SCRAM-SHA-1")
           .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) ).build() },
       { // multi-server CR
         new MongoProperties.Builder()
@@ -112,48 +114,52 @@ public class ClientWrapperIT extends TestBase {
           .set( MongoProp.USERNAME, (String) testProperties.get( "userpass.auth.user" ) )
           .set( MongoProp.PASSWORD, (String) testProperties.get( "userpass.auth.password" ) )
           .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
+          .set(MongoProp.AUTH_DATABASE,(String) testProperties.get("auth.db"))
+          .set(MongoProp.AUTH_MECHA,"SCRAM-SHA-1")
           .set( MongoProp.connectionsPerHost, "100" )
           .set( MongoProp.connectTimeout, "10000" )
           .set( MongoProp.maxWaitTime, "12000" )
           .set( MongoProp.readPreference, "primary" )
           .set( MongoProp.cursorFinalizerEnabled, "true" )
-          .set( MongoProp.socketKeepAlive, "false" )
-          .set( MongoProp.socketTimeout, "0" ).build() },
+          .set( MongoProp.socketKeepAlive, "true" )
+          .set( MongoProp.socketTimeout, "30000" ).build() },
       { // secondary read pref CR
         new MongoProperties.Builder()
           .set( MongoProp.HOST, (String) testProperties.get( "multiserver.host" ) )
           .set( MongoProp.USERNAME, (String) testProperties.get( "userpass.auth.user" ) )
           .set( MongoProp.PASSWORD, (String) testProperties.get( "userpass.auth.password" ) )
           .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
+          .set(MongoProp.AUTH_DATABASE,(String) testProperties.get("auth.db"))
+          .set(MongoProp.AUTH_MECHA,"SCRAM-SHA-1")
           .set( MongoProp.readPreference, "secondary" )
           .set( MongoProp.writeConcern, Integer.toString( NUM_MONGOS ) )
           .set( MongoProp.cursorFinalizerEnabled, "true" ).build() },
-      { // secondary read pref CR with tag set1
-        new MongoProperties.Builder()
-          .set( MongoProp.HOST, (String) testProperties.get( "multiserver.host" ) )
-          .set( MongoProp.USERNAME, (String) testProperties.get( "userpass.auth.user" ) )
-          .set( MongoProp.PASSWORD, (String) testProperties.get( "userpass.auth.password" ) )
-          .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
-          .set( MongoProp.readPreference, "secondary" )
-          .set( MongoProp.tagSet, (String) testProperties.get( "tagset1" ) )
-          .set( MongoProp.writeConcern, Integer.toString( NUM_MONGOS ) ).build() },
-      { // secondary read pref CR with tag set2
-        new MongoProperties.Builder()
-          .set( MongoProp.HOST, (String) testProperties.get( "multiserver.host" ) )
-          .set( MongoProp.USERNAME, (String) testProperties.get( "userpass.auth.user" ) )
-          .set( MongoProp.PASSWORD, (String) testProperties.get( "userpass.auth.password" ) )
-          .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
-          .set( MongoProp.readPreference, "secondary" )
-          .set( MongoProp.tagSet, (String) testProperties.get( "tagset2" ) )
-          .set( MongoProp.writeConcern, Integer.toString( NUM_MONGOS ) ).build() },
-      { // SSL turned on
-        new MongoProperties.Builder()
-          .set( MongoProp.HOST, (String) testProperties.get( "ssl.host" ) )
-          .set( MongoProp.USERNAME, (String) testProperties.get( "ssl.user" ) )
-          .set( MongoProp.PASSWORD, (String) testProperties.get( "ssl.password" ) )
-          .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
-          .set( MongoProp.USE_ALL_REPLICA_SET_MEMBERS, "false" )
-          .set( MongoProp.useSSL, "true" ).build() }
+//      { // secondary read pref CR with tag set1
+//        new MongoProperties.Builder()
+//          .set( MongoProp.HOST, (String) testProperties.get( "multiserver.host" ) )
+//          .set( MongoProp.USERNAME, (String) testProperties.get( "userpass.auth.user" ) )
+//          .set( MongoProp.PASSWORD, (String) testProperties.get( "userpass.auth.password" ) )
+//          .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
+//          .set( MongoProp.readPreference, "secondary" )
+//          .set( MongoProp.tagSet, (String) testProperties.get( "tagset1" ) )
+//          .set( MongoProp.writeConcern, Integer.toString( NUM_MONGOS ) ).build() },
+//      { // secondary read pref CR with tag set2
+//        new MongoProperties.Builder()
+//          .set( MongoProp.HOST, (String) testProperties.get( "multiserver.host" ) )
+//          .set( MongoProp.USERNAME, (String) testProperties.get( "userpass.auth.user" ) )
+//          .set( MongoProp.PASSWORD, (String) testProperties.get( "userpass.auth.password" ) )
+//          .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
+//          .set( MongoProp.readPreference, "secondary" )
+//          .set( MongoProp.tagSet, (String) testProperties.get( "tagset2" ) )
+//          .set( MongoProp.writeConcern, Integer.toString( NUM_MONGOS ) ).build() },
+//      { // SSL turned on
+//        new MongoProperties.Builder()
+//          .set( MongoProp.HOST, (String) testProperties.get( "ssl.host" ) )
+//          .set( MongoProp.USERNAME, (String) testProperties.get( "ssl.user" ) )
+//          .set( MongoProp.PASSWORD, (String) testProperties.get( "ssl.password" ) )
+//          .set( MongoProp.DBNAME, (String) testProperties.get( "test.db" ) )
+//          .set( MongoProp.USE_ALL_REPLICA_SET_MEMBERS, "false" )
+//          .set( MongoProp.useSSL, "true" ).build() }
     } );
   }
 
@@ -174,7 +180,7 @@ public class ClientWrapperIT extends TestBase {
       fail( "Could not retrieve replica set status with properties:  " + props );
     }
 
-    final MongoCursorWrapper cursor = wrapper.getCollection( props.get( MongoProp.DBNAME ), "sales" ).find();
+    final MongoCursorWrapper cursor = wrapper.getCollection( props.get( MongoProp.DBNAME ), "inventory" ).find();
 
     cursor.next();
     ServerAddress readServer = cursor.getServerAddress();

--- a/src/it/resources/test.properties
+++ b/src/it/resources/test.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2017 Hitachi Vantara. All rights reserved.
+#  Copyright 2002 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual
@@ -21,19 +21,20 @@
 #
 
 # properties for testing with CR credentials.
-single.server.host=bad-mongodb-301-kerb-n1.pentaho.dmz
+single.server.host=svdorlmongosnap2.orl.eng.hitachivantara.com
 userpass.auth.port=27017
-userpass.auth.user=PentahoUser
-userpass.auth.password=password
-test.db=foodmart
+userpass.auth.user=batman
+userpass.auth.password=Pentaho06
+auth.db=admin
+test.db=test
 
-multiserver.host=bad-mongodb-301-kerb-n1:27017,bad-mongodb-301-kerb-n2:27017,bad-mongodb-301-kerb-n3:27017,bad-mongodb-301-kerb-n4:27017,bad-mongodb-301-kerb-n5:27017
-ssl.host=bad-mongodb-301-ssl-n1.pentaho.dmz:27017,bad-mongodb-301-ssl-n2.pentaho.dmz:27017,bad-mongodb-301-ssl-n3.pentaho.dmz:27017,bad-mongodb-301-ssl-n4.pentaho.dmz:27017,bad-mongodb-301-ssl-n5.pentaho.dmz:27017
+multiserver.host=svdorlmongosnap1.orl.eng.hitachivantara.com,svdorlmongosnap2.orl.eng.hitachivantara.com,svdorlmongosnap3.orl.eng.hitachivantara.com
+#ssl.host=bad-mongodb-301-ssl-n1.pentaho.dmz:27017,bad-mongodb-301-ssl-n2.pentaho.dmz:27017,bad-mongodb-301-ssl-n3.pentaho.dmz:27017,bad-mongodb-301-ssl-n4.pentaho.dmz:27017,bad-mongodb-301-ssl-n5.pentaho.dmz:27017
 
-ssl.user=
-ssl.password=
-kerberos.user=buildguy@PENTAHO.DMZ
-kerberos.keytab=target/kerberos.keytab
+#ssl.user=
+#ssl.password=
+#kerberos.user=buildguy@PENTAHO.DMZ
+#kerberos.keytab=target/kerberos.keytab
 
-tagset1={"dc": "west", "use":"reporting"}
-tagset2={"dc":"east", "use":"reporting"},{ "dc": "west", "use":"reporting"}
+#tagset1={"dc": "west", "use":"reporting"}
+#tagset2={"dc":"east", "use":"reporting"},{ "dc": "west", "use":"reporting"}


### PR DESCRIPTION
BACKLOG-35409: Fixed integration tests for pentaho-mongo-utils project
Out of the existing commented code, we have resolved the following test cases:
- LDAP single server connection
- LDAP multi-server primary read preference
- LDAP multi-server secondary read preference
Note:
Except for Test cases related to Kerberos and SSL, rest all tests were fixed and tested. Test cases related to Kerberos & SSL cannot be automated for MongoDB through the Integration Testing framework given the challenge to replicate / configure certain aspects dynamically like placing krb5.conf file in every client machine. Testing of Kerberos and SSL scenarios are covered through creating and automating ktr files which will complement the integration testing and makes it complete in terms of MongoDB overall testing from developers perspective.
